### PR TITLE
[Fix] get streak days if > required and > 1 day old

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/playstreak.test.ts
+++ b/src/playstreak.test.ts
@@ -114,6 +114,21 @@ describe('get playstreak test', () => {
         }
       )
     })
+
+    test('8 out of 7 days but 2 days old', () => {
+      const old = new Date(Date.now() - 2 * oneDayInMs).toUTCString()
+      testGetPlaystreakDays(
+        {
+          lastPlaySessionCompletedDateTimeUTC: old,
+          requiredStreakInDays: 7,
+          currentStreakInDays: 8
+        },
+        {
+          currentStreakInDays: 7,
+          requiredStreakInDays: 7
+        }
+      )
+    })
   })
 })
 

--- a/src/playstreak.ts
+++ b/src/playstreak.ts
@@ -43,6 +43,10 @@ export function getPlayStreakDays({
   requiredStreakInDays,
   currentStreakInDays
 }: GetPlayStreakDaysArgs): GetPlayStreakDaysReturn {
+  // if a streak is > required, it will not reset until claim
+  if (currentStreakInDays > requiredStreakInDays) {
+    return { requiredStreakInDays, currentStreakInDays: requiredStreakInDays }
+  }
   if (questWillResetOnNextSession(lastPlaySessionCompletedDateTimeUTC)) {
     return { requiredStreakInDays, currentStreakInDays: 0 }
   }


### PR DESCRIPTION
We do not reset streaks > 1 day old if current streak is > required, so we should reflect that in the UI